### PR TITLE
Simplify updating the exif tags dump file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # If exifread is installed locally (e.g. pip install -e .), use it, else fallback to uv
 EXIF_PY := $(if $(shell which EXIF.py),EXIF.py,uvx --from exifread EXIF.py)
 
+# Find images, support multiple case insensitive extensions and file names with spaces
+FIND_IMAGES := find . -regextype posix-egrep -iregex ".*\.(bmp|gif|heic|heif|jpg|jpeg|png|tiff|webp)" -print0 | sort -fz | xargs -0
+
 .PHONY: help
 all: help
 
@@ -8,10 +11,10 @@ uv: ## Install/update uv (simplifies fetching and running EXIF.py in a venv)
 	pip3 install -q -U --user uv
 
 test: ## Run exifread on all sample images
-	find . -name *.tiff -o -name *.jpg -o -name *.heif | sort -f | xargs $(EXIF_PY) -dc
+	$(FIND_IMAGES) $(EXIF_PY) -dc
 
 update: ## Update dump file with tags from sample images
-	find . -name *.tiff -o -name *.jpg -o -name *.heif | sort -f | xargs $(EXIF_PY) > dump
+	$(FIND_IMAGES) $(EXIF_PY) > dump
 	@# Edit dump to match CI of exifread and remove trailing whitespace
 	sed -i -e 's/Opening: ./Opening: exif-samples-master/g' -e 's/[ \t]*$$//' dump
 	@git diff --quiet dump || echo "\033[1;31mChanges detected, commit updates to 'dump'."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# If exifread is installed locally (e.g. pip install -e .), use it, else fallback to uv
+EXIF_PY := $(if $(shell which EXIF.py),EXIF.py,uvx --from exifread EXIF.py)
+
+.PHONY: help
+all: help
+
+uv: ## Install/update uv (simplifies fetching and running EXIF.py in a venv)
+	pip3 install -q -U --user uv
+
+test: ## Run exifread on all sample images
+	find . -name *.tiff -o -name *.jpg -o -name *.heif | sort -f | xargs $(EXIF_PY) -dc
+
+update: ## Update dump file with tags from sample images
+	find . -name *.tiff -o -name *.jpg -o -name *.heif | sort -f | xargs $(EXIF_PY) > dump
+	@# Edit dump to match CI of exifread and remove trailing whitespace
+	sed -i -e 's/Opening: ./Opening: exif-samples-master/g' -e 's/[ \t]*$$//' dump
+	@git diff --quiet dump || echo "\033[1;31mChanges detected, commit updates to 'dump'."
+
+help: Makefile
+	@echo
+	@echo "Choose a command to run:"
+	@echo
+	@grep --no-filename -E '^[a-zA-Z_%-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf " \033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 EXIF_PY := $(if $(shell which EXIF.py),EXIF.py,uvx --from exifread EXIF.py)
 
 # Find images, support multiple case insensitive extensions and file names with spaces
-FIND_IMAGES := find . -regextype posix-egrep -iregex ".*\.(bmp|gif|heic|heif|jpg|jpeg|png|tiff|webp)" -print0 | sort -fz | xargs -0
+FIND_IMAGES := find . -regextype posix-egrep -iregex ".*\.(bmp|gif|heic|heif|jpg|jpeg|png|tiff|webp)" -print0 | LC_COLLATE=C sort -fz | xargs -0
 
 .PHONY: help
 all: help

--- a/README.rst
+++ b/README.rst
@@ -10,3 +10,17 @@ Adding Images
 Please do!
 
 User-contributed images will be released under the **Attribution-ShareAlike 4.0 International** license.
+
+Keeping the Dump File in Sync
+=============================
+
+To keep the dump file synchronized with the sample images, use the following commands:
+
+.. code-block:: bash
+
+   # if exifread is not installed locally
+   make uv
+
+   make update
+
+   # if needed, commit changes to 'dump'

--- a/dump
+++ b/dump
@@ -3629,6 +3629,121 @@ Thumbnail ResolutionUnit (Short): Pixels/Inch
 Thumbnail XResolution (Ratio): 72
 Thumbnail YResolution (Ratio): 72
 
+Opening: exif-samples-master/jpg/tests/32-lens_data.jpeg
+File has JPEG thumbnail
+EXIF CVAPattern (Undefined): [0, 2, 0, 2, 0, 1, 1, 2]
+EXIF ColorSpace (Short): sRGB
+EXIF ComponentsConfiguration (Undefined): YCbCr
+EXIF CompressedBitsPerPixel (Ratio): 2
+EXIF Contrast (Short): Normal
+EXIF CustomRendered (Short): Normal
+EXIF DateTimeDigitized (ASCII): 2012:07:14 16:30:12
+EXIF DateTimeOriginal (ASCII): 2012:07:14 16:30:12
+EXIF DigitalZoomRatio (Ratio): 1
+EXIF ExifImageLength (Short): 0
+EXIF ExifImageWidth (Short): 0
+EXIF ExifVersion (Undefined): 0221
+EXIF ExposureBiasValue (Signed Ratio): 0
+EXIF ExposureMode (Short): Auto Exposure
+EXIF ExposureProgram (Short): Aperture Priority
+EXIF ExposureTime (Ratio): 1/500
+EXIF FNumber (Ratio): 28/5
+EXIF FileSource (Undefined): Digital Camera
+EXIF Flash (Short): Flash did not fire
+EXIF FlashPixVersion (Undefined): 0100
+EXIF FocalLength (Ratio): 105
+EXIF FocalLengthIn35mmFilm (Short): 157
+EXIF GainControl (Short): None
+EXIF ISOSpeedRatings (Short): 200
+EXIF InteroperabilityOffset (Long): 8980
+EXIF LightSource (Short): Unknown
+EXIF MakerNote (Undefined): [78, 105, 107, 111, 110, 0, 2, 0, 0, 0, 77, 77, 0, 42, 0, 0, 0, 8, 0, 49, ... ]
+EXIF MaxApertureValue (Ratio): 49/10
+EXIF MeteringMode (Short): Pattern
+EXIF Saturation (Short): Normal
+EXIF SceneCaptureType (Short): Standard
+EXIF SceneType (Undefined): Directly Photographed
+EXIF SensingMethod (Short): One-chip color area
+EXIF Sharpness (Short): Normal
+EXIF SubSecTime (ASCII): 68
+EXIF SubSecTimeDigitized (ASCII): 68
+EXIF SubSecTimeOriginal (ASCII): 68
+EXIF SubjectDistanceRange (Short): 0
+EXIF UserComment (Undefined):
+EXIF WhiteBalance (Short): Auto
+GPS GPSVersionID (Byte): [2, 2, 0, 0]
+Image Artist (ASCII): Ilya Kurikhin
+Image Copyright (ASCII): Ilya Kurikhin
+Image DateTime (ASCII): 2014:11:19 18:08:04
+Image ExifOffset (Long): 342
+Image GPSInfo (Long): 9010
+Image Make (ASCII): NIKON CORPORATION
+Image Model (ASCII): NIKON D300
+Image Orientation (Short): Horizontal (normal)
+Image ResolutionUnit (Short): Pixels/Inch
+Image Software (ASCII): GIMP 2.8.10
+Image XResolution (Ratio): 300
+Image YCbCrPositioning (Short): Co-sited
+Image YResolution (Ratio): 300
+Interoperability InteroperabilityIndex (ASCII): R98
+Interoperability InteroperabilityVersion (Undefined): [48, 49, 48, 48]
+MakerNote AEBracketCompensationApplied (Signed Ratio): 0
+MakerNote AFInfo2 (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 49, 48, 48, 0, 0, 0, 100, 20, 246, 0, 0, 0, 0, 0, 0, 0, 0]
+MakerNote AFTune (Undefined): [0, 255, 0, 0]
+MakerNote ActiveDLighting (Short): 0
+MakerNote AutoBracketRelease (Short): 1
+MakerNote AutoFlashMode (ASCII):
+MakerNote BracketingMode (Short): Continuous, no bracketing
+MakerNote ColorBalance (Undefined): []
+MakerNote ColorSpace (Short): 1
+MakerNote CropHiSpeed (Short): [13110, 13312, 12337, 12336, 257, 0, 12337]
+MakerNote ExposureDifference (Undefined): 0 EV
+MakerNote ExposureTuning (Undefined): [0, 1, 6]
+MakerNote ExternalFlashExposureComp (Undefined): 0 EV
+MakerNote FileInfo (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... ]
+MakerNote FlashBracketCompensationApplied (Undefined): 0 EV
+MakerNote FlashCompensation (Undefined): 0 EV
+MakerNote FlashInfo (Undefined): [0, 0, 0, 0, 48, 49, 48, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 218]
+MakerNote FlashMode (Byte): Did Not Fire
+MakerNote FlashSetting (ASCII):
+MakerNote FocusMode (ASCII):
+MakerNote HighISONoiseReduction (Short): 0
+MakerNote ISOInfo (Undefined): [0, 0, 0, 10, 0, 0, 11, 184, 0, 0, 0, 10, 0, 0]
+MakerNote ISOSetting (Short): [0, 200]
+MakerNote ISOSpeedRequested (Short): [0, 200]
+MakerNote ImageAuthentication (Byte): 0
+MakerNote ImageDataSize (Long): 4283904
+MakerNote LensData (Undefined): [171, 28, 20, 247, 91, 244, 169, 206, 229, 232, 230, 204, 166, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+MakerNote LensFStops (Undefined): [64, 1, 12, 0]
+MakerNote LensMinMaxFocalMaxAperture (Ratio): [7/2, 1835008/333849, 412623731/495358395, 1282302404/4273759655]
+MakerNote LensType (Byte): 14
+MakerNote MakernoteVersion (Undefined): 0210
+MakerNote MultiExposure (Undefined): [4, 25, 10, 51, 0, 0, 48, 49, 48, 48, 0, 0, 1, 1, 1, 0]
+MakerNote NikonPreview (Long): 8014
+MakerNote NoiseReduction (ASCII):
+MakerNote PhotoCornerCoordinates (Short): [4352, 2868, 4352, 2868]
+MakerNote PictureControl (Undefined): [0, 0, 0, 0, 0, 0, 83, 84, 65, 78, 68, 65, 82, 68, 0, 0, 0, 0, 0, 0, ... ]
+MakerNote PowerUpTime (Undefined): [0, 0, 0, 0, 0, 0, 0, 0]
+MakerNote ProgramShift (Undefined): 0 EV
+MakerNote Quality (ASCII):
+MakerNote RetouchHistory (Short): [0, 12337, 12339, 0, 0, 0, 255, 0, 0, 0]
+MakerNote SerialNumber (ASCII): 00STANDA
+MakerNote ShotInfo (Undefined): []
+MakerNote Tag 0x00A3 (Byte): 0
+MakerNote TotalShutterReleases (Long): 241575
+MakerNote VRInfo (Undefined): [82, 68, 0, 0, 0, 0, 0, 0]
+MakerNote WhiteBalanceBias (Signed Short): [0, 0]
+MakerNote WhiteBalanceRBCoeff (Ratio): [1, 1, 67/2916352, 0]
+MakerNote Whitebalance (ASCII):
+MakerNote WorldTime (Undefined): [0, 180, 0, 2]
+Thumbnail Compression (Short): JPEG (old-style)
+Thumbnail JPEGInterchangeFormat (Long): 9134
+Thumbnail JPEGInterchangeFormatLength (Long): 3538
+Thumbnail ResolutionUnit (Short): Pixels/Inch
+Thumbnail XResolution (Ratio): 300
+Thumbnail YCbCrPositioning (Short): Co-sited
+Thumbnail YResolution (Ratio): 300
+
 Opening: exif-samples-master/jpg/tests/33-type_error.jpg
 File has JPEG thumbnail
 EXIF ApertureValue (Ratio): 290241/62500

--- a/dump
+++ b/dump
@@ -1,3 +1,6 @@
+Opening: exif-samples-master/heic/mobile/HMD_Nokia_8.3_5G.heif
+No EXIF information found
+
 Opening: exif-samples-master/heic/mobile/HMD_Nokia_8.3_5G_hdr.heif
 EXIF ExposureProgram (Short): Unidentified
 EXIF ExposureTime (Ratio): 1/125
@@ -26,9 +29,6 @@ Image ExifOffset (Long): 110
 Image GPSInfo (Long): 250
 Image Orientation (Short): Horizontal (normal)
 Image Software (ASCII): 00WW_2_270_SP04
-
-Opening: exif-samples-master/heic/mobile/HMD_Nokia_8.3_5G.heif
-No EXIF information found
 
 Opening: exif-samples-master/heic/samplefilehub.heif
 Image Orientation (Short): Horizontal (normal)
@@ -2650,35 +2650,6 @@ Image YResolution (Ratio): 72
 Thumbnail JPEGInterchangeFormat (Long): 702
 Thumbnail JPEGInterchangeFormatLength (Long): 1322
 
-Opening: exif-samples-master/jpg/mobile/HMD_Nokia_8.3_5G_hdr.jpg
-EXIF ApertureValue (Ratio): 189/100
-EXIF DateTimeOriginal (ASCII): 2021:07:29 21:28:46
-EXIF ExposureProgram (Short): Unidentified
-EXIF ExposureTime (Ratio): 8333/500000
-EXIF FNumber (Ratio): 189/100
-EXIF Flash (Short): Flash did not fire
-EXIF FocalLength (Ratio): 271/50
-EXIF ISOSpeedRatings (Short): 601
-EXIF MeteringMode (Short): CenterWeightedAverage
-EXIF OffsetTime (ASCII): +03:00
-EXIF OffsetTimeDigitized (ASCII): +03:00
-EXIF OffsetTimeOriginal (ASCII): +03:00
-EXIF WhiteBalance (Short): Auto
-GPS GPSDate (ASCII): 2021:07:29
-GPS GPSImgDirection (Ratio): 178
-GPS GPSImgDirectionRef (ASCII): M
-GPS GPSLatitude (Signed Ratio): [60, 59, 2897/100]
-GPS GPSLatitudeRef (ASCII): N
-GPS GPSLongitude (Signed Ratio): [24, 25, 2709/100]
-GPS GPSLongitudeRef (ASCII): E
-GPS GPSTimeStamp (Ratio): [18, 28, 47]
-Image ExifOffset (Long): 126
-Image GPSInfo (Long): 361
-Image Make (ASCII): HMD Global
-Image Model (ASCII): Nokia 8.3 5G
-Image Orientation (Short): Rotated 90 CW
-Image Software (ASCII): 00WW_2_270_SP01
-
 Opening: exif-samples-master/jpg/mobile/HMD_Nokia_8.3_5G.jpg
 EXIF ApertureValue (Ratio): 11/5
 EXIF DateTimeOriginal (ASCII): 2022:08:14 14:12:31
@@ -2707,6 +2678,35 @@ Image Make (ASCII): HMD Global
 Image Model (ASCII): Nokia 8.3 5G
 Image Orientation (Short): Horizontal (normal)
 Image Software (ASCII): 00WW_3_380_SP02
+
+Opening: exif-samples-master/jpg/mobile/HMD_Nokia_8.3_5G_hdr.jpg
+EXIF ApertureValue (Ratio): 189/100
+EXIF DateTimeOriginal (ASCII): 2021:07:29 21:28:46
+EXIF ExposureProgram (Short): Unidentified
+EXIF ExposureTime (Ratio): 8333/500000
+EXIF FNumber (Ratio): 189/100
+EXIF Flash (Short): Flash did not fire
+EXIF FocalLength (Ratio): 271/50
+EXIF ISOSpeedRatings (Short): 601
+EXIF MeteringMode (Short): CenterWeightedAverage
+EXIF OffsetTime (ASCII): +03:00
+EXIF OffsetTimeDigitized (ASCII): +03:00
+EXIF OffsetTimeOriginal (ASCII): +03:00
+EXIF WhiteBalance (Short): Auto
+GPS GPSDate (ASCII): 2021:07:29
+GPS GPSImgDirection (Ratio): 178
+GPS GPSImgDirectionRef (ASCII): M
+GPS GPSLatitude (Signed Ratio): [60, 59, 2897/100]
+GPS GPSLatitudeRef (ASCII): N
+GPS GPSLongitude (Signed Ratio): [24, 25, 2709/100]
+GPS GPSLongitudeRef (ASCII): E
+GPS GPSTimeStamp (Ratio): [18, 28, 47]
+Image ExifOffset (Long): 126
+Image GPSInfo (Long): 361
+Image Make (ASCII): HMD Global
+Image Model (ASCII): Nokia 8.3 5G
+Image Orientation (Short): Rotated 90 CW
+Image Software (ASCII): 00WW_2_270_SP01
 
 Opening: exif-samples-master/jpg/mobile/jolla.jpg
 EXIF ApertureValue (Ratio): 334328577/132351334

--- a/dump
+++ b/dump
@@ -1,3 +1,35 @@
+Opening: exif-samples-master/heic/mobile/HMD_Nokia_8.3_5G_hdr.heif
+EXIF ExposureProgram (Short): Unidentified
+EXIF ExposureTime (Ratio): 1/125
+EXIF FNumber (Ratio): 189/100
+EXIF Flash (Short): Flash did not fire
+EXIF FocalLength (Ratio): 1
+EXIF ISOSpeedRatings (Short): 100
+EXIF MeteringMode (Short): CenterWeightedAverage
+EXIF SubSecTime (ASCII): 364
+EXIF WhiteBalance (Short): Auto
+GPS GPSAltitude (Ratio): 4701593/5000
+GPS GPSAltitudeRef (Byte): 0
+GPS GPSDate (ASCII): 2022:01:12
+GPS GPSImgDirection (Ratio): 82
+GPS GPSImgDirectionRef (ASCII): M
+GPS GPSLatitude (Ratio): [40, 39, 233883/5000]
+GPS GPSLatitudeRef (ASCII): N
+GPS GPSLongitude (Ratio): [3, 45, 12366459/250000]
+GPS GPSLongitudeRef (ASCII): W
+GPS GPSProcessingMethod (ASCII): gps
+GPS GPSSpeed (Ratio): 7559/10000
+GPS GPSSpeedRef (ASCII): K
+GPS GPSTimeStamp (Ratio): [7, 30, 14]
+Image DateTime (ASCII): 2022:01:12 07:30:14
+Image ExifOffset (Long): 110
+Image GPSInfo (Long): 250
+Image Orientation (Short): Horizontal (normal)
+Image Software (ASCII): 00WW_2_270_SP04
+
+Opening: exif-samples-master/heic/mobile/HMD_Nokia_8.3_5G.heif
+No EXIF information found
+
 Opening: exif-samples-master/heic/samplefilehub.heif
 Image Orientation (Short): Horizontal (normal)
 Image ResolutionUnit (Short): Pixels/Inch
@@ -2617,6 +2649,64 @@ Image XResolution (Ratio): 72
 Image YResolution (Ratio): 72
 Thumbnail JPEGInterchangeFormat (Long): 702
 Thumbnail JPEGInterchangeFormatLength (Long): 1322
+
+Opening: exif-samples-master/jpg/mobile/HMD_Nokia_8.3_5G_hdr.jpg
+EXIF ApertureValue (Ratio): 189/100
+EXIF DateTimeOriginal (ASCII): 2021:07:29 21:28:46
+EXIF ExposureProgram (Short): Unidentified
+EXIF ExposureTime (Ratio): 8333/500000
+EXIF FNumber (Ratio): 189/100
+EXIF Flash (Short): Flash did not fire
+EXIF FocalLength (Ratio): 271/50
+EXIF ISOSpeedRatings (Short): 601
+EXIF MeteringMode (Short): CenterWeightedAverage
+EXIF OffsetTime (ASCII): +03:00
+EXIF OffsetTimeDigitized (ASCII): +03:00
+EXIF OffsetTimeOriginal (ASCII): +03:00
+EXIF WhiteBalance (Short): Auto
+GPS GPSDate (ASCII): 2021:07:29
+GPS GPSImgDirection (Ratio): 178
+GPS GPSImgDirectionRef (ASCII): M
+GPS GPSLatitude (Signed Ratio): [60, 59, 2897/100]
+GPS GPSLatitudeRef (ASCII): N
+GPS GPSLongitude (Signed Ratio): [24, 25, 2709/100]
+GPS GPSLongitudeRef (ASCII): E
+GPS GPSTimeStamp (Ratio): [18, 28, 47]
+Image ExifOffset (Long): 126
+Image GPSInfo (Long): 361
+Image Make (ASCII): HMD Global
+Image Model (ASCII): Nokia 8.3 5G
+Image Orientation (Short): Rotated 90 CW
+Image Software (ASCII): 00WW_2_270_SP01
+
+Opening: exif-samples-master/jpg/mobile/HMD_Nokia_8.3_5G.jpg
+EXIF ApertureValue (Ratio): 11/5
+EXIF DateTimeOriginal (ASCII): 2022:08:14 14:12:31
+EXIF ExposureProgram (Short): Unidentified
+EXIF ExposureTime (Ratio): 541/1000000
+EXIF FNumber (Ratio): 11/5
+EXIF Flash (Short): Flash did not fire
+EXIF FocalLength (Ratio): 11/4
+EXIF ISOSpeedRatings (Short): 100
+EXIF MeteringMode (Short): CenterWeightedAverage
+EXIF OffsetTime (ASCII): +03:00
+EXIF OffsetTimeDigitized (ASCII): +03:00
+EXIF OffsetTimeOriginal (ASCII): +03:00
+EXIF WhiteBalance (Short): Auto
+GPS GPSDate (ASCII): 2022:08:14
+GPS GPSImgDirection (Ratio): 56
+GPS GPSImgDirectionRef (ASCII): M
+GPS GPSLatitude (Signed Ratio): [60, 8, 2407/50]
+GPS GPSLatitudeRef (ASCII): N
+GPS GPSLongitude (Signed Ratio): [24, 54, 1219/50]
+GPS GPSLongitudeRef (ASCII): E
+GPS GPSTimeStamp (Ratio): [11, 12, 32]
+Image ExifOffset (Long): 126
+Image GPSInfo (Long): 361
+Image Make (ASCII): HMD Global
+Image Model (ASCII): Nokia 8.3 5G
+Image Orientation (Short): Horizontal (normal)
+Image Software (ASCII): 00WW_3_380_SP02
 
 Opening: exif-samples-master/jpg/mobile/jolla.jpg
 EXIF ApertureValue (Ratio): 334328577/132351334


### PR DESCRIPTION
This PR addresses the issue where adding images to the repository without updating the dump file breaks the tests for exifread.

**Key Changes:**

- Added a Makefile to replicate the tests for exifread, as inspired from [the CI workflow](https://github.com/ianare/exif-py/blob/develop/.github/workflows/test.yml#L51). Improved flexibility for various extensions and file names.
- In case EXIF.py isn't locally installed (e.g., for contributors who don't develop exifread), I opted to leverage [uv](https://astral.sh/blog/uv-unified-python-packaging) to fetch the latest published version of exifread and run it in a virtual environment.
- Updated the dump file by including the necessary fixes from [PR #173](https://github.com/ianare/exif-py/pull/173) and [PR #196](https://github.com/ianare/exif-py/pull/196) due to issues with HEIF files in the latest version of exifread.

Please see the related [PR #202](https://github.com/ianare/exif-py/pull/202) that mirrors the changes to correctly find all image files in the `exifread` repository.

I welcome any feedback or suggestions on these changes!

## 🐍 🤹‍♂️ 